### PR TITLE
:rat: jsdom replaced by tabletojson to fix key:value output order

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jsdom": "^11.3.0",
     "moment-timezone": "^0.5.14",
     "request": "^2.83.0",
+    "tabletojson": "^0.6.0",
     "winston": "^2.4.0"
   },
   "devDependencies": {

--- a/src/models/Character.js
+++ b/src/models/Character.js
@@ -1,78 +1,32 @@
-const { getTextContent } = require('../utils/dom.utils')
 const { tibiaTime2Moment } = require('../utils/conversors.utils')
 
 class Character {
-  constructor(dom) {
-    this._dom = dom
+  constructor (table) {
+    this._table = table
   }
 
-  playerDoesntExists() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table > tbody > tr:nth-child(1) > td > b'
-    const title = getTextContent(this._dom, selector)
-    return /not find/gi.test(title)
+  playerDoesntExists () {
+    if (this._table.name === undefined) {
+      return "Player doesn't exists"
+    }
   }
 
-  get name() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(2) > td:nth-child(2)'
-    return getTextContent(this._dom, selector)
-  }
-  get sex() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(3) > td:nth-child(2)'
-    return getTextContent(this._dom, selector)
-  }
-  get vocation() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(4) > td:nth-child(2)'
-    return getTextContent(this._dom, selector)
-  }
-  get level() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(5) > td:nth-child(2)'
-    return getTextContent(this._dom, selector)
-  }
-  get achievementPoints() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(6) > td:nth-child(2)'
-    return getTextContent(this._dom, selector)
-  }
-  get world() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(7) > td:nth-child(2)'
-    return getTextContent(this._dom, selector)
-  }
-  get residence() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(8) > td:nth-child(2)'
-    return getTextContent(this._dom, selector)
-  }
-  get lastLogin() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(9) > td:nth-child(2)'
-    const time = getTextContent(this._dom, selector)
-    const formattedTime = tibiaTime2Moment(time)
-
-    return formattedTime.format()
-  }
-  get accountStatus() {
-    const selector =
-      '#characters > div.Border_2 > div > div > table:nth-child(1) > tbody > tr:nth-child(10) > td:nth-child(2)'
-    return getTextContent(this._dom, selector)
-  }
-
-  get allCharacterInformation() {
+  get allCharacterInformation () {
     return {
-      name: this.name,
-      sex: this.sex,
-      vocation: this.vocation,
-      level: this.level,
-      achievementPoints: this.achievementPoints,
-      world: this.world,
-      residence: this.residence,
-      lastLogin: this.lastLogin,
-      accountStatus: this.accountStatus,
+      name: this._table.name,
+      formerNames: this._table.formernames,
+      sex: this._table.sex,
+      vocation: this._table.vocation,
+      level: this._table.level,
+      achievementPoints: this._table.achievementpoints,
+      world: this._table.world,
+      formerWorld: this._table.formerworld,
+      residence: this._table.residence,
+      house: this._table.house,
+      guildMembership: this._table.guildmembership,
+      lastLogin: tibiaTime2Moment(this._table.lastlogin).format(),
+      comment: this._table.comment,
+      accountStatus: this._table.accountstatus
     }
   }
 }

--- a/src/schemas/Character.js
+++ b/src/schemas/Character.js
@@ -9,6 +9,10 @@ const CharacterType = new GraphQLObjectType({
       type: GraphQLString,
       resolve: character => character.name,
     },
+    formerNames: {
+      type: GraphQLString,
+      resolve: character => character.formerNames,
+    },
     sex: {
       type: GraphQLString,
       resolve: character => character.sex,
@@ -29,13 +33,29 @@ const CharacterType = new GraphQLObjectType({
       type: GraphQLString,
       resolve: character => character.world,
     },
+    formerWorld: {
+      type: GraphQLString,
+      resolve: character => character.formerWorld,
+    },
     residence: {
       type: GraphQLString,
       resolve: character => character.residence,
     },
+    house: {
+      type: GraphQLString,
+      resolve: character => character.house,
+    },
+    guildMembership: {
+      type: GraphQLString,
+      resolve: character => character.guildMembership,
+    },
     lastLogin: {
       type: GraphQLString,
       resolve: character => character.lastLogin,
+    },
+    comment: {
+      type: GraphQLString,
+      resolve: character => character.comment,
     },
     accountStatus: {
       type: GraphQLString,

--- a/src/services/character.service.js
+++ b/src/services/character.service.js
@@ -1,4 +1,4 @@
-const { getDomFromURL } = require('../utils/dom.utils')
+const { getTableFromURL } = require('../utils/tabletojson.utils')
 const { hasSpecificLength } = require('../utils/validations.utils')
 
 const Character = require('../models/Character')
@@ -18,9 +18,9 @@ const getCharacterInfos = (playerName = '') =>
 
     try {
       const url = `https://secure.tibia.com/community/?subtopic=characters&name=${playerName}`
-      const dom = await getDomFromURL(url)
+      const table = await getTableFromURL(url)
 
-      const character = new Character(dom)
+      const character = new Character(table)
       if (character.playerDoesntExists()) {
         logger.log('info', "Player doesn't exists")
         reject("Player doesn't exists")

--- a/src/utils/conversors.utils.js
+++ b/src/utils/conversors.utils.js
@@ -1,14 +1,13 @@
 const { hasSpecificLength } = require('./validations.utils')
 const momentTZ = require('moment-timezone')
 
-
 const tibiaTime2Moment = (tibiaTime = '') => {
 
   if (hasSpecificLength({ target: tibiaTime, length: 0 })) {
     throw new Error('time is required')
   }
   
-  const newTibiaTime = new momentTZ(tibiaTime,'MMM DD YYYY, HH:mm:ss')
+  const newTibiaTime = new momentTZ(tibiaTime, 'MMM DD YYYY, HH:mm:ss')
 
   if (!newTibiaTime.isValid()) {
     throw new Error('Invalid time.')

--- a/src/utils/tabletojson.utils.js
+++ b/src/utils/tabletojson.utils.js
@@ -1,0 +1,28 @@
+const tabletojson = require('tabletojson')
+const { hasSpecificLength } = require('./validations.utils')
+
+const logger = require('winston')
+
+const getTableFromURL = (url = '') =>
+  new Promise(async (resolve, reject) => {
+    if (hasSpecificLength({ target: url, length: 0 })) {
+      reject(new Error('URL is required'))
+    }
+
+    try {
+      let info = {}
+      tabletojson.convertUrl(url).then((tablesAsJson) => {
+        for (let i = 1; i < tablesAsJson[0].length; i += 1) {
+          info[tablesAsJson[0][i][0].replace(/\s|:/g, '').toLowerCase()] = tablesAsJson[0][i][1]
+        }
+        resolve(info)
+      })
+    } catch (error) {
+      logger.log('error', error)
+      reject(error)
+    }
+  })
+
+module.exports = {
+  getTableFromURL
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,6 +202,12 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
+async@^2.0.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
+  dependencies:
+    lodash "^4.14.0"
+
 async@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
@@ -397,11 +403,21 @@ binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
 
+bl@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.0.3.tgz#fc5421a28fd4226036c3b3891a66a25bc64d226e"
+  dependencies:
+    readable-stream "~2.0.5"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
 boom@2.x.x:
   version "2.10.1"
@@ -521,6 +537,16 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+cheerio@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.19.0.tgz#772e7015f2ee29965096d71ea4175b75ab354925"
+  dependencies:
+    css-select "~1.0.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "~3.8.1"
+    lodash "^3.2.0"
 
 chokidar@^1.4.3:
   version "1.6.1"
@@ -702,6 +728,19 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
+css-select@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.0.0.tgz#b1121ca51848dd264e2244d058cee254deeb44b0"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "1.0"
+    domutils "1.4"
+    nth-check "~1.0.0"
+
+css-what@1.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-1.0.0.tgz#d7cc2df45180666f99d2b14462639469e00f736c"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
@@ -820,9 +859,43 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
+domelementtype@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
 domexception@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.0.tgz#81fe5df81b3f057052cde3a9fa9bf536a85b9ab0"
+
+domhandler@2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.4:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.4.3.tgz#0865513796c6b306031850e175516baf80b72a6f"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 duplexer@~0.1.1:
   version "0.1.1"
@@ -856,6 +929,14 @@ end-of-stream@1.0.0:
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e"
   dependencies:
     once "~1.3.0"
+
+entities@1.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
+
+entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
 "errno@>=0.1.1 <0.2.0-0":
   version "0.1.4"
@@ -1260,6 +1341,14 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
+form-data@~1.0.0-rc3:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-1.0.1.tgz#ae315db9a4907fa065502304a66d7733475ee37c"
+  dependencies:
+    async "^2.0.1"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.11"
+
 form-data@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.2.tgz#89c3534008b97eada4cbb157d58f6f5df025eae4"
@@ -1495,7 +1584,7 @@ har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
 
-har-validator@~2.0.6:
+har-validator@~2.0.2, har-validator@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
   dependencies:
@@ -1542,7 +1631,7 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-hawk@3.1.3, hawk@~3.1.3:
+hawk@3.1.3, hawk@~3.1.0, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
   dependencies:
@@ -1584,6 +1673,16 @@ html-encoding-sniffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+htmlparser2@~3.8.1:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.8.3.tgz#996c28b191516a8be86501a7d79757e5c70c1068"
+  dependencies:
+    domelementtype "1"
+    domhandler "2.3"
+    domutils "1.5"
+    entities "1.0"
+    readable-stream "1.1"
 
 http-errors@1.6.2, http-errors@^1.3.0:
   version "1.6.2"
@@ -1828,6 +1927,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -2422,6 +2525,10 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
+lodash@^3.2.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -2505,17 +2612,17 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
+mime-types@^2.1.11, mime-types@~2.1.16, mime-types@~2.1.17:
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  dependencies:
+    mime-db "~1.30.0"
+
 mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.7:
   version "2.1.14"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee"
   dependencies:
     mime-db "~1.26.0"
-
-mime-types@~2.1.16, mime-types@~2.1.17:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
-  dependencies:
-    mime-db "~1.30.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -2637,6 +2744,10 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+node-uuid@~1.4.7:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
+
 nodemon@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.11.0.tgz#226c562bd2a7b13d3d7518b49ad4828a3623d06c"
@@ -2708,6 +2819,12 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -2720,7 +2837,7 @@ nwmatcher@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.0, oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -3008,9 +3125,17 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
+q@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
+
 qs@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
+
+qs@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.1.tgz#801fee030e0b9450d6385adc48a4cc55b44aedfc"
 
 qs@~6.3.0:
   version "6.3.0"
@@ -3099,6 +3224,15 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+readable-stream@1.1:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
@@ -3121,6 +3255,17 @@ readable-stream@^2.1.4, readable-stream@^2.2.2:
     process-nextick-args "~1.0.6"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@~2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
 readable-stream@~2.1.4:
@@ -3194,6 +3339,31 @@ request-promise-native@^1.0.3:
     request-promise-core "1.1.1"
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
+
+request@2.67.0:
+  version "2.67.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.67.0.tgz#8af74780e2bf11ea0ae9aa965c11f11afd272742"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    bl "~1.0.0"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~1.0.0-rc3"
+    har-validator "~2.0.2"
+    hawk "~3.1.0"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    node-uuid "~1.4.7"
+    oauth-sign "~0.8.0"
+    qs "~5.2.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.2.0"
+    tunnel-agent "~0.4.1"
 
 request@2.81.0:
   version "2.81.0"
@@ -3657,6 +3827,14 @@ table@^4.0.1:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
+tabletojson@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tabletojson/-/tabletojson-0.6.0.tgz#15bb55d68d78b53edc8c42c21afe82cfcd7ca06e"
+  dependencies:
+    cheerio "0.19.0"
+    q "1.4.1"
+    request "2.67.0"
+
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -3748,6 +3926,10 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+tough-cookie@~2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.2.2.tgz#c83a1830f4e5ef0b93ef2a3488e724f8de016ac7"
 
 tr46@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Hello!!!

The current api gives a **key:value** output order incorrect depending on which player has been  requested.

**It works:**
`query { player(nickname: "Mad Dentist") }`

**It doesn't work as expected:**
`query { player(nickname: "Dig Storm") }`

**Why?** New _tr/td_ fields breaks the selector number for each player attribute.
Additional fields are added to the player info table depending on which player has been  requested. 

**Some additional fields**: _Former Names, House, Guild Membership, Etc._

I've replaced **jsdom** by **tabletojson** to get the whole table instead of each element by dom selector. _It may have to be refactored though._

**Here is an output example:**

![old-vs-new](https://user-images.githubusercontent.com/25266300/32801383-04eada24-c964-11e7-8933-dc24e8f7b9ba.jpg)

_**lastLogin** date on this screenshot doesn't had **tibiaTime2Moment** implemented yet. This pull request already have._

**Some Notes:** 

`npm run lint` wasn't already passing all requirements. We've to fix it later

The **character service test** also wasn't rewrote to test additional fields yet.


I think that's it for now! Hope you like it! :smiley: Congratz for this awesome job! :tada:


